### PR TITLE
Simplify cassette_name and modify method_name regex to work in a varitety of cases

### DIFF
--- a/lib/vcr_helper.rb
+++ b/lib/vcr_helper.rb
@@ -34,7 +34,10 @@ module VcrHelper
     if self.respond_to?(:described_class)
       build_rspec_cassette_name(self.example.metadata).join("_").underscore.gsub('/','_').gsub(' ', '_').gsub(/[^a-z0-9\s_]/, '')
     else
-      (self.class.name.underscore.gsub('/','_') + '__' + self.method_name.gsub(/^test[:_](\s?)/, '')).strip.downcase.squeeze(' ').gsub(/[^a-z0-9\s_]/, '').gsub(' ', '_')
+      test_class = self.class.name.underscore.gsub('/','_')
+      test_method = self.method_name.gsub(/^test[:_]+(\s?)/, '')
+      class_and_method = (test_class + '__' + test_method)
+      class_and_method.strip.downcase.squeeze(' ').gsub(/[^a-z0-9\s_]/, '').gsub(' ', '_')
     end
   end
 


### PR DESCRIPTION
Something changed in a recent version of Shoulda where some method names are now `test_: the test method` where before it appears they were `test: the test method`. The issue is due to `gsub` calls further down this chain we get an extra underscore in the filename.

This is super bad because it looks like VCR is failing to recognize my requests. It was really tough to figure out b/c the file name is joined on two underscores `__` and with the upgrade of Shoulda it's now joined on three undscores `___` super tough to figure out at a glance.

So the regex change is only to replace `test` follow by _either_ a colon or underscore. Previously the regex only matched _one_ colon or underscore.

```
old = /^test[:_](\s?)/`
new = /^test[:_]+(\s?)/
```

I used Rubular.com to confirm the regex change since there aren't tests. I can also confirm my VCR tests are working as expected with this change in my project.
### Before

![rubular_ a ruby regular expression editor and tester](https://cloud.githubusercontent.com/assets/12533/11829802/2a95415c-a354-11e5-84df-3d19263505a3.jpg)
### After

![rubular_ a ruby regular expression editor and tester-1](https://cloud.githubusercontent.com/assets/12533/11829819/4c340f5a-a354-11e5-82a3-a545b0431ce0.jpg)
